### PR TITLE
candlemass: 0.2.0 changed it from +8% to +5% max hp

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -513,7 +513,7 @@
     {
       "Name": "Metadata/Terrain/Woods/Manor/Features/Chapel_boss_01.tdt",
       "ExpectedCount": 1,
-      "DisplayName": "Candlemass (+8% Max Life)"
+      "DisplayName": "Candlemass (+5% Max Life)"
     },
     {
       "Name": "Metadata/Terrain/Woods/Manor/Interior/Features/ThickWall_OpenDoor_01.tdt",


### PR DESCRIPTION
Content Update 0.2.0 changed Candlemass reward (Optional boss of Ogham Manor) down from +8% to +5% max hp.